### PR TITLE
Bugfix: remove stray newline in column fitting code

### DIFF
--- a/src/SingleOrigin/utils.py
+++ b/src/SingleOrigin/utils.py
@@ -2390,9 +2390,7 @@ def fit_gaussian_group(
                     (y0-pos_bound_dist/2, y0+pos_bound_dist),
                     (1, 1.2),
                     (0, None),
-                ] * num
-
-                + [(0, None)]
+                ] * num + [(0, None)]
                 method = 'L-BFGS-B'
 
             else:


### PR DESCRIPTION
A stray newline in the column-fitting procedure causes an error when `use_circ_gauss is True`: the newline made a list concatenation look like unary addition, throwing the error:

> TypeError: bad operand type for unary +: 'list'

This commit removes the extra newline, which resolves the issue.