### PR TITLE
Minor documentation fix

### DIFF
--- a/src/SingleOrigin/find_atom_columns.py
+++ b/src/SingleOrigin/find_atom_columns.py
@@ -194,7 +194,7 @@ class HRImage:
             project_uc_2d() method applied. See examples for how to generate
             this.
 
-        origin_atom_column : int
+        origin_atom_column : int | None
             The DataFrame row index (in unitcell.at_cols) of the atom column
             that is later picked by the user to register the reference lattice.
             If None, the closest atom column to the unit cell origin is


### PR DESCRIPTION
Minor fix of documented type signature of `origin_atom_column` parameter of `add_lattice`method. Specifically, added None as a valid type:
https://github.com/sdfunni/SingleOrigin/blob/5d5c71acb2ebad01c94ed81ac20077497d44a48a/src/SingleOrigin/find_atom_columns.py#L197

This really only matters for IDEs that do automatic type checking (which flag `origin_atom_column=None` as being incorrect).